### PR TITLE
roundcube: tests - add space to db password, check setup script worked

### DIFF
--- a/nixos/tests/roundcube.nix
+++ b/nixos/tests/roundcube.nix
@@ -9,7 +9,7 @@ import ./make-test.nix ({ pkgs, ...} : {
       services.roundcube = {
         enable = true;
         hostName = "roundcube";
-        database.password = "notproduction";
+        database.password = "not production";
         package = pkgs.roundcube.withPlugins (plugins: [ plugins.persistent_login ]);
         plugins = [ "persistent_login" ];
       };
@@ -23,6 +23,7 @@ import ./make-test.nix ({ pkgs, ...} : {
   testScript = ''
     $roundcube->start;
     $roundcube->waitForUnit("postgresql.service");
+    $roundcube->waitForUnit("roundcube-setup.service");
     $roundcube->waitForUnit("phpfpm-roundcube.service");
     $roundcube->waitForUnit("nginx.service");
     $roundcube->succeed("curl -sSfL http://roundcube/ | grep 'Keep me logged in'");


### PR DESCRIPTION
###### Motivation for this change

- This PR extends the test for roundcube. It now checks that `roundcube-setup.service` (which populates the database) succeeds.
- Without your patch, the old test would fail if the db password had a space in it (once it found roundcube wasn't working), but now it would fail more quickly.
- The test's db password now has a space in it, and the test passes with your patch.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
